### PR TITLE
Make compatible with pyDeltaRCM v2 and add example notebook

### DIFF
--- a/BMI_pyDeltaRCM/bmidelta.py
+++ b/BMI_pyDeltaRCM/bmidelta.py
@@ -78,7 +78,7 @@ class BmiDelta(Bmi):
         'coeff__velocity_erosion_sand': 'coeff_U_ero_sand',
         'coeff__topographic_diffusion': 'alpha',
         'basin__opt_subsidence': 'toggle_subsidence',
-        'basin__maximum_subsidence_rate': 'sigma_max',
+        'basin__maximum_subsidence_rate': 'subsidence_rate',
         'basin__subsidence_start_timestep': 'start_subsidence',
         'basin__opt_stratigraphy': 'save_strata'
     }

--- a/BMI_pyDeltaRCM/bmidelta.py
+++ b/BMI_pyDeltaRCM/bmidelta.py
@@ -8,7 +8,8 @@ from bmipy import Bmi
 import yaml
 
 from pyDeltaRCM.model import DeltaModel
-from pyDeltaRCM.preprocessor import write_yaml_config_to_file
+from pyDeltaRCM.preprocessor import _write_yaml_config_to_file \
+    as write_yaml_config_to_file
 
 from . import utils
 
@@ -511,7 +512,7 @@ class BmiDelta(Bmi):
     def get_grid_x(self, grid: int) -> np.ndarray:
         """Get coordinates of grid nodes in the x direction.
 
-        .. hint:: 
+        .. hint::
             Internally, the pyDeltaRCM model refers to the down-stream
             direction as `x`, which is the row-coordinate of the grid, and
             opposite the BMI specification.
@@ -534,7 +535,7 @@ class BmiDelta(Bmi):
     def get_grid_y(self, grid: int) -> np.ndarray:
         """Get coordinates of grid nodes in the y direction.
 
-        .. hint:: 
+        .. hint::
             Internally, the pyDeltaRCM model refers to the cross-stream
             direction as `y`, which is the column-coordinate of the grid, and
             opposite the BMI specification.

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Or for a developer installation run:
 Executing the model
 ###################
 
-The below code provides the most basic method for initializing and running
+The below code provides the simplest method for initializing and running
 the pyDeltaRCM model using the BMI interface.
 
 .. code:: python

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,6 @@ Documentation
 
 `Find the full documentation here <https://deltarcm.org/BMI_pyDeltaRCM/index.html>`_.
 
-
-
 Installation
 ############
 
@@ -41,4 +39,12 @@ Or for a developer installation run:
 Executing the model
 ###################
 
-todo
+The below code provides the most basic method for initializing and running
+the pyDeltaRCM model using the BMI interface.
+
+.. code:: python
+
+    from BMI_pyDeltaRCM.bmidelta import BmiDelta
+    delta = BmiDelta()  # instantiate model
+    delta.initialize()  # initialize model
+    delta.update()  # update model

--- a/example_notebook/BMI_Example.ipynb
+++ b/example_notebook/BMI_Example.ipynb
@@ -1,0 +1,204 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "75ad7f2c-0347-483c-b8a3-9d9661bf6a2f",
+   "metadata": {},
+   "source": [
+    "## How to run the pyDeltaRCM model via the CSDMS BMI\n",
+    "\n",
+    "This quick notebook outlines how the [pyDeltaRCM model](https://github.com/DeltaRCM/pyDeltaRCM) can be accessed and used via the [Basic Model Interface (BMI)](https://bmi.readthedocs.io/en/latest/index.html).\n",
+    "\n",
+    "This requires installation of the [BMI_pyDeltaRCM package](https://github.com/DeltaRCM/BMI_pyDeltaRCM) which handles the conversion of pyDeltaRCM variables to their BMI counterparts under the hood."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32b11f4d-a935-420b-ac2c-e982f2d21bb1",
+   "metadata": {},
+   "source": [
+    "### Step 1: Import packages\n",
+    "\n",
+    "We import matplotlib for plotting, and the `BmiDelta` object from the BMI_pyDeltaRCM package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f23d8f7b-c9e4-4cc4-af6d-67ea17d0c152",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from BMI_pyDeltaRCM.bmidelta import BmiDelta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0f8f149-b4aa-4ff2-903f-a66013eb418c",
+   "metadata": {},
+   "source": [
+    "### Step 2: Model initialization\n",
+    "\n",
+    "We instantiate our model by simply calling it and assigning it a variable name, then we can check that the model instance we've created is a pyDeltaRCM model.\n",
+    "\n",
+    "Once we've done that, we can check the configuration YAML file we are using for this model run. Note that this configuration file uses [CSDMS Standard Names](https://csdms.colorado.edu/wiki/CSDMS_Standard_Names), as opposed to the pyDeltaRCM input variable names.\n",
+    "\n",
+    "Using the YAML configuration file, the model can be initialized by calling `delta.initialize(<yaml file>)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c9ae37c-544e-40a9-b32d-221a885be0f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define model instance\n",
+    "delta = BmiDelta()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eedb5195-a6f1-406f-b741-c6e00c36cfdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check that it is a pyDeltaRCM model\n",
+    "print(delta.get_component_name())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fc32d2c-5328-4b03-9204-62ff2cdd6c9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check configuration file\n",
+    "cat newrun.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49e5c479-13d7-4d00-bc4e-6291ac4039d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# initialize the model\n",
+    "delta.initialize('newrun.yaml')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b58f94f0-4ff2-4348-9853-44d1158374a2",
+   "metadata": {},
+   "source": [
+    "### Step 3: Update the model\n",
+    "\n",
+    "Using the BMI framework, we can update our model.\n",
+    "\n",
+    "First we'll query some timekeeping invoration to understand the current state of the model, as well as the timestep and its size.\n",
+    "\n",
+    "Then we will print out a bunch of variable names to get a feeling for what the model contains. To see the effect of the model update, we will save the initial topography as a variable, update the model, and then plot the difference between the new, updated, topography and the intial topography."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cc242b4-2baf-468b-b9b7-c2abb364a89d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print timekeeping information\n",
+    "print('Start time:', delta.get_start_time())\n",
+    "print('End time:', delta.get_end_time())\n",
+    "print('Current time:', delta.get_current_time())\n",
+    "print('Time step:', delta.get_time_step())\n",
+    "print('Time units:', delta.get_time_units())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37372218-b0b0-46f1-9580-6260a0b4166f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print model variable names\n",
+    "print(delta.get_input_var_names())\n",
+    "print(delta.get_output_var_names())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b046309-b4b6-4f6d-a578-ff422a32a49d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# write initial topography to a variable\n",
+    "initial_topo = delta.get_value('sea_bottom_surface__elevation')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36a600ba-be0d-47e1-af13-5438d34c22ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# advance model a timestep\n",
+    "delta.update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee322e06-7030-44ef-aeda-a11057abae46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get the updated topography\n",
+    "updated_topo = delta.get_value('sea_bottom_surface__elevation')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e14b9d66-59da-4c74-8c19-9e8ae801daf1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot the difference between updated and initial topography (blue = deposition, red = erosion)\n",
+    "plt.figure(dpi=200)\n",
+    "plt.imshow(updated_topo - initial_topo, cmap='bwr_r', vmin=-0.35, vmax=0.35)\n",
+    "plt.colorbar(fraction=0.035)\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:pydeltarcm] *",
+   "language": "python",
+   "name": "conda-env-pydeltarcm-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/example_notebook/newrun.yaml
+++ b/example_notebook/newrun.yaml
@@ -1,0 +1,2 @@
+model__random_seed: 50
+model_grid__cell_size: 50

--- a/tests/test_bmidelta.py
+++ b/tests/test_bmidelta.py
@@ -498,8 +498,6 @@ class TestBmiOperations:
         delta.update_until(2)
         assert delta._delta._time == 2.
 
-    @pytest.mark.xfail(raises=ValueError, strict=False,
-                       reason="Recalculation of Np_water on timestep change causes break. Upstream error.")
     def test_update_frac(self, tmp_path):
         filename = 'user_parameters.yaml'
         p, f = create_temporary_file(tmp_path, filename)
@@ -507,7 +505,6 @@ class TestBmiOperations:
         f.close()
         delta = BmiDelta()
         delta.initialize(p)
-        # with pytest.warns(UserWarning):
         delta.update_frac(0.2)
         assert delta._delta.time_step == 25000.0
 
@@ -714,8 +711,6 @@ class TestBmiApiReqts:
         delta.initialize(p)
         assert delta.get_end_time() == pytest.approx(np.finfo('d').max)
 
-    @pytest.mark.xfail(raises=AttributeError, strict=False,
-                       reason='Upstream changes needed to make time public')
     def test_get_current_time(self, tmp_path):
         filename = 'user_parameters.yml'
         p, f = create_temporary_file(tmp_path, filename)

--- a/tests/test_bmidelta.py
+++ b/tests/test_bmidelta.py
@@ -31,7 +31,7 @@ class TestBmiInputParameters:
         delta.initialize(p)
         assert delta._delta.h0 == 5.0
         assert delta._delta.u0 == 1.0
-        assert delta._delta.S0 == 0.0002
+        assert delta._delta.S0 == 0.00015
 
     def test_set_model_output__out_dir_config(self, tmp_path):
         filename = 'user_parameters.yaml'
@@ -462,7 +462,7 @@ class TestBmiInputParameters:
         f.close()
         delta = BmiDelta()
         delta.initialize(p)
-        assert delta._delta.sigma_max == 0.00033
+        assert delta._delta.subsidence_rate == 0.00033
 
     def test_set_basin__subsidence_start_timestep_config(self, tmp_path):
         filename = 'user_parameters.yaml'
@@ -473,16 +473,6 @@ class TestBmiInputParameters:
         delta = BmiDelta()
         delta.initialize(p)
         assert delta._delta.start_subsidence == 10
-
-    def test_set_basin__opt_stratigraphy_config(self, tmp_path):
-        filename = 'user_parameters.yaml'
-        p, f = create_temporary_file(tmp_path, filename)
-        write_parameter_to_file(f, 'basin__opt_stratigraphy', True)
-        write_parameter_to_file(f, 'model_output__out_dir', tmp_path / 'out_dir')
-        f.close()
-        delta = BmiDelta()
-        delta.initialize(p)
-        assert delta._delta.save_strata is True
 
 
 class TestBmiOperations:
@@ -495,7 +485,7 @@ class TestBmiOperations:
         delta = BmiDelta()
         delta.initialize(p)
         delta.update()
-        assert delta._delta._time == 1
+        assert delta._delta._time == 25000.0
 
     def test_update_until(self, tmp_path):
         filename = 'user_parameters.yaml'
@@ -508,8 +498,8 @@ class TestBmiOperations:
         delta.update_until(2)
         assert delta._delta._time == 2.
 
-    @pytest.mark.xfail(raises=ValueError, strict=True,
-                       reason="Recalcualtion of Np_water on timestep change causes break. Upstream error.")
+    @pytest.mark.xfail(raises=ValueError, strict=False,
+                       reason="Recalculation of Np_water on timestep change causes break. Upstream error.")
     def test_update_frac(self, tmp_path):
         filename = 'user_parameters.yaml'
         p, f = create_temporary_file(tmp_path, filename)
@@ -517,9 +507,9 @@ class TestBmiOperations:
         f.close()
         delta = BmiDelta()
         delta.initialize(p)
-        with pytest.warns(UserWarning):
-            delta.update_frac(0.2)
-        assert delta._delta.time_step == 1.0
+        # with pytest.warns(UserWarning):
+        delta.update_frac(0.2)
+        assert delta._delta.time_step == 25000.0
 
 
 class TestBmiApiReqts:
@@ -606,7 +596,7 @@ class TestBmiApiReqts:
         delta.initialize(p)
         _id = delta.get_var_grid('sea_water_surface__elevation')
         assert delta.get_grid_rank(_id) == 2
-        
+
     def test_get_grid_size(self, tmp_path):
         filename = 'user_parameters.yml'
         p, f = create_temporary_file(tmp_path, filename)
@@ -626,7 +616,7 @@ class TestBmiApiReqts:
         delta.initialize(p)
         assert np.all(delta.get_value('sea_water_surface__elevation') == delta._delta.stage)
         # make sure a copy is returned
-        assert delta.get_value('sea_water_surface__elevation') is not delta._delta.stage 
+        assert delta.get_value('sea_water_surface__elevation') is not delta._delta.stage
 
     def test_get_value_at_indices(self, tmp_path):
         filename = 'user_parameters.yml'
@@ -724,7 +714,7 @@ class TestBmiApiReqts:
         delta.initialize(p)
         assert delta.get_end_time() == pytest.approx(np.finfo('d').max)
 
-    @pytest.mark.xfail(raises=AttributeError, strict=True,
+    @pytest.mark.xfail(raises=AttributeError, strict=False,
                        reason='Upstream changes needed to make time public')
     def test_get_current_time(self, tmp_path):
         filename = 'user_parameters.yml'


### PR DESCRIPTION
Updates code and tests to make the BMI wrapper work with pyDeltaRCM v2

Also adds a MWE of using the BMI to the readme and a simple example notebook.