### PR TITLE
Cron Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,11 @@
 
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 1 * *'  # run at 12 AM first day of every month
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,10 +52,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - name: Set up Python 3.x
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,10 +52,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - name: Set up Python 3.8
+    - name: Set up Python 3.x
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Documentation
 Installation
 ############
 
-.. important::
+**Note:**
 
     If you intend to manipulate the underlying *pyDeltaRCM* code in any way, be sure to follow the `Developer Installation instructions <https://deltarcm.org/pyDeltaRCM/meta/installing.html#developer-installation>`_ from that project before installing the BMI wrapper.
 
@@ -51,4 +51,4 @@ the pyDeltaRCM model using the BMI interface.
     delta.initialize()  # initialize model
     delta.update()  # update model
 
-See the `BMI_pyDeltaRCM USer Guide <https://deltarcm.org/BMI_pyDeltaRCM/userguide.html>`_.
+See the `BMI_pyDeltaRCM User Guide <https://deltarcm.org/BMI_pyDeltaRCM/userguide.html>`_.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,1 @@
-sphinx==2.0.1
+sphinx

--- a/tests/test_bmidelta.py
+++ b/tests/test_bmidelta.py
@@ -1,7 +1,6 @@
 import pytest
-
 import numpy as np
-
+from bmipy import Bmi
 from BMI_pyDeltaRCM import BmiDelta
 
 
@@ -19,6 +18,11 @@ def write_parameter_to_file(f, varname, varvalue):
 
 
 # TESTS #
+def test_bmi_implemented():
+    """Test based on the same name test in the CSDMS/bmi-python repo."""
+    assert isinstance(BmiDelta(), Bmi)
+    
+
 class TestBmiInputParameters:
     """Tests associated with the input parameters of the BMI"""
 


### PR DESCRIPTION
PR does the following:

- runs the continuous integration (`build.yml`) at 12 AM on the first day of every month
- Fixes formatting and typo in the Readme
- Adds a test for proper inheritance of the `Bmi` class following [this test](https://github.com/csdms/bmi-python/blob/1aa3129f5075bc6415c4607f60d635c56f0b4c91/tests/test_bmipy.py#L142) in the CSDMS bmi-python repository
- Unpins the sphinx version for the docs build as the original upstream issue that made us pin the version has since been resolved